### PR TITLE
Fixes the "no output.name" error.

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -276,6 +276,7 @@ async function createLegacyChunk(
   // Generate the legacy bundle.
   const { output } = await bundle.generate({
     entryFileNames: legacyPath,
+    name: viteBuild.lib ? viteBuild.lib.name : undefined,
     format: 'iife',
     sourcemap: viteBuild.sourcemap,
     sourcemapExcludeSources: true,


### PR DESCRIPTION
Without a name, the bundle exports can't be accessed.

```log
$ vite build -c vite.legacy.config.ts
vite v2.0.2 building for production...
✓ 19 modules transformed.
rendering chunks (1)...creating legacy bundle...
If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
dist/lit-element-sample.iife.js          29.59kb / brotli: 6.94kb
dist/lit-element-sample.iife.js.map      155.20kb
dist/lit-element-sample.iife.legacy.js   85.81kb / brotli: 25.34kb
dist/lit-element-sample.iife.legacy.js.map 117.21kb
✨  Done in 6.98s.
```